### PR TITLE
Add new filter parseInt

### DIFF
--- a/client/goats/runtime/filters/filters.js
+++ b/client/goats/runtime/filters/filters.js
@@ -1,6 +1,7 @@
 goog.provide('goats.runtime.filters');
 
 goog.require('goog.object');
+goog.require('goog.math');
 goog.require('goog.string');
 goog.require('goog.string.format');
 
@@ -145,6 +146,18 @@ goats.runtime.filters.format = function(f, var_args) {
 	return goog.string.format.apply(null, args);
 };
 
+/**
+ * Parse integer from string or integer.
+ *
+ * @param {string} val the string or integer.
+ * @returns {string} The result.
+ */
+goats.runtime.filters.parseInt = function(val) {
+	if (goog.math.isInt(val)) {
+		return val;
+	}
+        return goog.string.parseInt(val);
+};
 
 // ================ utility functions ================
 


### PR DESCRIPTION
protobuf3 protocol defines that int64 is transfered as string to json data.
goats-html user has to convert int64 string to int for comparison. 